### PR TITLE
Slice of operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/metrumresearchgroup/turnstile
+
+go 1.13
+
+require github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/turnstile.go
+++ b/turnstile.go
@@ -16,7 +16,7 @@ type Scalable interface {
 //Manager is what we will create first. It's the struct that will contain the details of the operations, total operational status, and the results
 type Manager struct {
 	Iterations  uint64
-	Operation   Scalable
+	Operations  []Scalable
 	Working     uint64
 	Completed   uint64
 	Errors      uint64
@@ -49,9 +49,9 @@ type OperationInputs struct {
 }
 
 //NewManager takes a few configuration options and prepares your work manager
-func NewManager(operation Scalable, iterations uint64, concurrency uint64) *Manager {
+func NewManager(operations []Scalable, iterations uint64, concurrency uint64) *Manager {
 	m := Manager{
-		Operation:   operation,
+		Operations:  operations,
 		Concurrency: concurrency,
 		Iterations:  iterations,
 	}
@@ -123,10 +123,11 @@ func (m *Manager) Execute() {
 		}
 	}()
 
-	for i := uint64(0); i < m.Iterations; i++ {
-		m.Work <- m.Operation
-	}
+	//Iterate over the scalables and put them onto the queue
 
+	for _, v := range m.Operations {
+		m.Work <- v
+	}
 }
 
 func (m *Manager) isComplete() bool {


### PR DESCRIPTION
Updating to take a slice of scalables as opposed to a single one and just iterate over it. This allow the content of the struct conforming to the Scalable interface to contain all the details relevant to its operation