### PR TITLE
fix: Making sure that the cancellation channel is checked after clean…

### DIFF
--- a/turnstile.go
+++ b/turnstile.go
@@ -93,6 +93,10 @@ func (m *Manager) Execute() {
 						}
 
 						work.Cleanup(&m.Channels)
+
+						//Process cancellation channels one last time to look
+						//for failures in the cleanup phase.
+						isCancelled(cancellationChannel, &m.Channels)
 					}()
 				}
 			}


### PR DESCRIPTION
…up phase to ensure a single entry point for all failure recordings